### PR TITLE
HCK-7045: add adapter to fix entity level properties

### DIFF
--- a/adapter/0.2.2.json
+++ b/adapter/0.2.2.json
@@ -40,16 +40,16 @@
  * }
  */
 {
-	"modify": {
+	"delete": {
 		"entity": [
 			{
-				"from": {
-					"partitioning": []
-				},
-				"to": {
-					"partitioning": "No partitioning"
-				}
-			},
+				"key": "partitioning",
+				"value": []
+			}
+		]
+	},
+	"modify": {
+		"entity": [
 			{
 				"from": {
 					"primaryKey": false

--- a/adapter/0.2.2.json
+++ b/adapter/0.2.2.json
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2016-2022 by IntegrIT S.A. dba Hackolade.  All rights reserved.
+ *
+ * The copyright to the computer software herein is the property of IntegrIT S.A.
+ * The software may be used and/or copied only with the written permission of
+ * IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+ * the agreement/contract under which the software has been supplied.
+ *
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+{
+	"modify": {
+		"entity": [
+			{
+				"from": {
+					"partitioning": []
+				},
+				"to": {
+					"partitioning": "No partitioning"
+				}
+			},
+			{
+				"from": {
+					"primaryKey": false
+				},
+				"to": {
+					"primaryKey": []
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7045" title="HCK-7045" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-7045</a>  Add an adapter to fix wrong format of entity level properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Two entity-level properties (`partitioning`, `primaryKey`) may be out of sync with the entity-level config, which prevents the opening of such models. 
This adapter fixes those properties with the wrong values and sets the value to the default one.
