### PR TITLE
fix partitioning property adapter, set default value

### DIFF
--- a/adapter/0.2.2.json
+++ b/adapter/0.2.2.json
@@ -40,16 +40,13 @@
  * }
  */
 {
-	"delete": {
-		"entity": [
-			{
-				"key": "partitioning",
-				"value": []
-			}
-		]
-	},
 	"modify": {
 		"entity": [
+			[
+				"assignProperties",
+				{ "key": "partitioning", "valueType": "array" },
+				{ "partitioning": "No partitioning" }
+			],
 			{
 				"from": {
 					"primaryKey": false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7045" title="HCK-7045" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-7045</a>  Add an adapter to fix wrong format of entity level properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Add substituting a wrong array type property by the default value for the `partitioning` property.

...