### PR TITLE
HCK-7254: fix FE script generation for the time unit partitioning using DATE type column

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -425,7 +425,7 @@ module.exports = (baseProvider, options, app) => {
 						},
 					}[tableOptions.format] || {},
 				),
-				properties: jsonSchema.properties,
+				properties: jsonSchema?.properties || {},
 			};
 		},
 
@@ -462,7 +462,7 @@ module.exports = (baseProvider, options, app) => {
 				enableRefresh: detailsTab.enableRefresh,
 				maxStaleness: detailsTab.maxStaleness,
 				allowNonIncrementalDefinition: detailsTab.allowNonIncrementalDefinition,
-				properties: jsonSchema.properties,
+				properties: jsonSchema?.properties || {},
 			};
 		},
 

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -78,6 +78,7 @@ module.exports = (baseProvider, options, app) => {
 				externalTableOptions,
 				foreignKeyConstraints,
 				primaryKey,
+				properties,
 			},
 			isActivated,
 		) {
@@ -95,6 +96,7 @@ module.exports = (baseProvider, options, app) => {
 				partitioningType,
 				timeUnitPartitionKey,
 				rangeOptions,
+				properties,
 			});
 			const clustering = getClusteringKey(clusteringKey, isActivated);
 			const isExternal = tableType === 'External';
@@ -205,6 +207,7 @@ module.exports = (baseProvider, options, app) => {
 				partitioningType: viewData.partitioningType,
 				timeUnitPartitionKey: viewData.timeUnitPartitionKey,
 				rangeOptions: viewData.rangeOptions,
+				properties: viewData.properties,
 			});
 			const clustering = getClusteringKey(viewData.clusteringKey, isActivated);
 			const partitionsStatement = commentIfDeactivated(partitions, { isActivated: isPartitionActivated });
@@ -422,6 +425,7 @@ module.exports = (baseProvider, options, app) => {
 						},
 					}[tableOptions.format] || {},
 				),
+				properties: jsonSchema.properties,
 			};
 		},
 
@@ -434,7 +438,7 @@ module.exports = (baseProvider, options, app) => {
 			};
 		},
 
-		hydrateView({ viewData, entityData }) {
+		hydrateView({ viewData, entityData, jsonSchema }) {
 			const detailsTab = entityData[0];
 
 			return {
@@ -458,6 +462,7 @@ module.exports = (baseProvider, options, app) => {
 				enableRefresh: detailsTab.enableRefresh,
 				maxStaleness: detailsTab.maxStaleness,
 				allowNonIncrementalDefinition: detailsTab.allowNonIncrementalDefinition,
+				properties: jsonSchema.properties,
 			};
 		},
 

--- a/forward_engineering/helpers/utils.js
+++ b/forward_engineering/helpers/utils.js
@@ -35,6 +35,14 @@ const getPartitioningByIntegerRange = (rangeOptions = {}) => {
 	return `RANGE_BUCKET(${name}, GENERATE_ARRAY(${start}, ${end}${isNaN(interval) ? '' : `, ${interval}`}))`;
 };
 
+const getPartitioningByTimeUnitColumn = ({ partitionTimeColumn, properties }) => {
+	if (properties?.[partitionTimeColumn]?.type === 'date') {
+		return wrapByBackticks(partitionTimeColumn);
+	}
+
+	return `DATE(${wrapByBackticks(partitionTimeColumn)})`;
+};
+
 const isActivatedPartition = ({ partitioning, timeUnitPartitionKey, rangeOptions }) => {
 	if (partitioning === 'By time-unit column') {
 		return timeUnitPartitionKey?.[0]?.isActivated;
@@ -47,7 +55,7 @@ const isActivatedPartition = ({ partitioning, timeUnitPartitionKey, rangeOptions
 	return true;
 };
 
-const getTablePartitioning = ({ partitioning, partitioningType, timeUnitPartitionKey, rangeOptions }) => {
+const getTablePartitioning = ({ partitioning, partitioningType, timeUnitPartitionKey, rangeOptions, properties }) => {
 	const partitionTimeColumn = timeUnitPartitionKey?.[0]?.name;
 
 	if (partitioning === 'No partitioning') {
@@ -59,7 +67,7 @@ const getTablePartitioning = ({ partitioning, partitioningType, timeUnitPartitio
 	}
 
 	if (partitioning === 'By time-unit column' && partitionTimeColumn) {
-		return `PARTITION BY DATE(${wrapByBackticks(partitionTimeColumn)})`;
+		return 'PARTITION BY ' + getPartitioningByTimeUnitColumn({ partitionTimeColumn, properties });
 	}
 
 	if (partitioning === 'By integer-range') {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7254" title="HCK-7254" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7254</a>  Fix BigQuery time-unit column partitioning FE script generation for the columns with DATE type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Context

Time-unit column partitioning is suitable for the `DATE`, `TIMESTAMP`, or `DATETIME` columns within a table. For more details, refer to the [documentation](https://cloud.google.com/bigquery/docs/partitioned-tables).

When defining a partition expression, ensure that columns of type `TIMESTAMP` or `DATETIME` are enclosed within the `DATE()` function. On the other hand, if you're using columns of type `DATE`, there's no need to include this wrapping function. ([documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#partition_expression))

## Technical details

To handle partitioning expressions for different column types, I created a helper function. This function generates the appropriate expression based on the type of column.