### PR TITLE
HCK-10442: add maxValue for length and an adapter to properly convert to Polyglot haxMaxLength property

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -66,6 +66,34 @@
 				"to": {
 					"dataTypeMode": "Nullable"
 				}
+			},
+			{
+				"from": {
+					"type": "varchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 9223372036854775807
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 9223372036854775807
+				}
+			},
+			{
+				"from": {
+					"type": "binary",
+					"mode": "varbinary",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 9223372036854775807
+				}
 			}
 		]
 	}

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -57,6 +57,24 @@
 				"to": {
 					"required": false
 				}
+			},
+			{
+				"from": {
+					"type": "string",
+					"length": 9223372036854775807
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"type": "bytes",
+					"length": 9223372036854775807
+				},
+				"to": {
+					"hasMaxLength": true
+				}
 			}
 		]
 	}

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -99,6 +99,7 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "numeric",
 				"valueType": "number",
 				"minValue": 1,
+				"maxValue": 9223372036854775807,
 				"step": 1,
 				"typeDecorator": true
 			},
@@ -206,6 +207,7 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "numeric",
 				"valueType": "number",
 				"minValue": 1,
+				"maxValue": 9223372036854775807,
 				"step": 1,
 				"typeDecorator": true
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10442" title="HCK-10442" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10442</a>  Implement max length mapping for RDBMS-like database targets (cross-target conversion)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added maxValue for length and an adapter to properly convert to Polyglot haxMaxLength property