### PR TITLE
HCK-10923: allow reverse-engineering in the browser

### DIFF
--- a/api/re.js
+++ b/api/re.js
@@ -1,0 +1,1 @@
+module.exports = require('../reverse_engineering/api');

--- a/forward_engineering/helpers/applyToInstanceHelper.js
+++ b/forward_engineering/helpers/applyToInstanceHelper.js
@@ -19,7 +19,7 @@ const execute = async (bigquery, query, location) => {
 const applyToInstance = async (connectionInfo, logger, app) => {
 	const _ = app.require('lodash');
 	const async = app.require('async');
-	const connection = connectionHelper.connect(connectionInfo);
+	const connection = await connectionHelper.connect(connectionInfo);
 	const dataLocation = connectionInfo.containerData?.[0]?.dataLocation;
 	const location = dataLocation === 'default' ? '' : dataLocation;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "BigQuery",
-	"version": "0.2.13",
+	"version": "0.2.15",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "BigQuery",
-			"version": "0.2.13",
+			"version": "0.2.15",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@google-cloud/bigquery": "5.7.1",
+				"@google-cloud/bigquery": "8.0.0",
 				"@hackolade/sql-select-statement-parser": "0.0.20",
-				"lodash": "4.17.21"
+				"fs-extra": "11.3.0"
 			},
 			"devDependencies": {
 				"@hackolade/hck-esbuild-plugins-pack": "0.0.1",
@@ -514,76 +514,102 @@
 			}
 		},
 		"node_modules/@google-cloud/bigquery": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-5.7.1.tgz",
-			"integrity": "sha512-YLs1sLKa2N1RzppI04ZCqUJ0WX9hMHggU/b9bYHqYlrtqXVBMmbqUJNOzKMC7GkiltMNsFav1Zyk5cJ7mfQGwQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.0.0.tgz",
+			"integrity": "sha512-CXm+SK4e/JRJJpwd2a38jx6/zgGrLcw4X3EcSZtY1D7sNGdTdmTB8LlQBAQe/UmM5pHdqrNxYOM1J/zgG5LKlQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@google-cloud/common": "^3.1.0",
-				"@google-cloud/paginator": "^3.0.0",
-				"@google-cloud/promisify": "^2.0.0",
-				"arrify": "^2.0.1",
-				"big.js": "^6.0.0",
-				"duplexify": "^4.0.0",
+				"@google-cloud/common": "^6.0.0",
+				"@google-cloud/paginator": "^6.0.0",
+				"@google-cloud/precise-date": "^5.0.0",
+				"@google-cloud/promisify": "^5.0.0",
+				"arrify": "^3.0.0",
+				"big.js": "^6.2.2",
+				"duplexify": "^4.1.3",
 				"extend": "^3.0.2",
 				"is": "^3.3.0",
-				"p-event": "^4.1.0",
 				"stream-events": "^1.0.5",
-				"uuid": "^8.0.0"
+				"teeny-request": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@google-cloud/common": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.10.0.tgz",
-			"integrity": "sha512-XMbJYMh/ZSaZnbnrrOFfR/oQrb0SxG4qh6hDisWCoEbFcBHV0qHQo4uXfeMCzolx2Mfkh6VDaOGg+hyJsmxrlw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.0.tgz",
+			"integrity": "sha512-IXh04DlkLMxWgYLIUYuHHKXKOUwPDzDgke1ykkkJPe48cGIS9kkL2U/o0pm4ankHLlvzLF/ma1eO86n/bkumIA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@google-cloud/projectify": "^2.0.0",
-				"@google-cloud/promisify": "^2.0.0",
-				"arrify": "^2.0.1",
-				"duplexify": "^4.1.1",
-				"ent": "^2.2.0",
+				"@google-cloud/projectify": "^4.0.0",
+				"@google-cloud/promisify": "^4.0.0",
+				"arrify": "^2.0.0",
+				"duplexify": "^4.1.3",
 				"extend": "^3.0.2",
-				"google-auth-library": "^7.14.0",
-				"retry-request": "^4.2.2",
-				"teeny-request": "^7.0.0"
+				"google-auth-library": "^10.0.0-rc.1",
+				"html-entities": "^2.5.2",
+				"retry-request": "^8.0.0",
+				"teeny-request": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@google-cloud/common/node_modules/@google-cloud/promisify": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
+			"integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@google-cloud/common/node_modules/arrify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@google-cloud/paginator": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
-			"integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
+			"integrity": "sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"arrify": "^2.0.0",
 				"extend": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@google-cloud/precise-date": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.0.tgz",
+			"integrity": "sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@google-cloud/projectify": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
-			"integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+			"integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@google-cloud/promisify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
-			"integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+			"integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@hackolade/hck-esbuild-plugins-pack": {
@@ -853,11 +879,44 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@types/caseless": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+			"integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+			"license": "MIT"
+		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.15.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+			"integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/request": {
+			"version": "2.48.12",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+			"integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/caseless": "*",
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"form-data": "^2.5.0"
+			}
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1060,18 +1119,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"license": "MIT",
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
-			}
-		},
 		"node_modules/acorn": {
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1096,15 +1143,12 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
 			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -1354,12 +1398,15 @@
 			}
 		},
 		"node_modules/arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+			"integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/async-function": {
@@ -1371,6 +1418,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT"
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
@@ -1429,9 +1482,9 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-			"integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+			"integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -1515,6 +1568,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -1648,6 +1702,18 @@
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/commander": {
 			"version": "11.0.0",
@@ -1818,6 +1884,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1900,21 +1975,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/ent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-			"integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"punycode": "^1.4.1",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-abstract": {
@@ -2017,7 +2077,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -2587,15 +2646,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -2691,12 +2741,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-text-encoding": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-			"integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2788,11 +2832,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+			"integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"mime-types": "^2.1.35",
+				"safe-buffer": "^5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
 		"node_modules/fs-extra": {
 			"version": "11.3.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
 			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -2866,32 +2925,31 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-			"integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+			"version": "7.0.0-rc.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.0.0-rc.4.tgz",
+			"integrity": "sha512-fwQMwbs3o8Odl/nc/rkQJwyHeOXdderOwmybUl0gkyTdZXMK1oSTWj4Em7gSogVJsRWDeHPXLY06+e8Rkr01iw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
-				"https-proxy-agent": "^5.0.0",
-				"is-stream": "^2.0.0",
-				"node-fetch": "^2.6.7"
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/gcp-metadata": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-			"integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.0-rc.1.tgz",
+			"integrity": "sha512-E6c+AdIaK1LNA839OyotiTca+B2IG1nDlMjnlcck8JjXn3fVgx57Ib9i6iL1/iqN7bA3EUQdcRRu+HqOCOABIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"gaxios": "^4.0.0",
+				"gaxios": "^7.0.0-rc.1",
+				"google-logging-utils": "^1.0.0",
 				"json-bigint": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -3076,39 +3134,30 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "7.14.1",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
-			"integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+			"version": "10.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.0.0-rc.2.tgz",
+			"integrity": "sha512-LjkDUtHV8mFFV0pDWpPTjUuAPd6WDBs2y/mTzGSmwQJkDRinOpQyu7e/0pqQoDoanKGwaQJH5729uZ+/5Uz8fw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"arrify": "^2.0.0",
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
-				"fast-text-encoding": "^1.0.0",
-				"gaxios": "^4.0.0",
-				"gcp-metadata": "^4.2.0",
-				"gtoken": "^5.0.4",
-				"jws": "^4.0.0",
-				"lru-cache": "^6.0.0"
+				"gaxios": "^7.0.0-rc.4",
+				"gcp-metadata": "^7.0.0-rc.1",
+				"google-logging-utils": "^1.0.0",
+				"gtoken": "^8.0.0-rc.1",
+				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
-		"node_modules/google-p12-pem": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
-			"integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
-			"deprecated": "Package is no longer maintained",
-			"license": "MIT",
-			"dependencies": {
-				"node-forge": "^1.3.1"
-			},
-			"bin": {
-				"gp12-pem": "build/src/bin/gp12-pem.js"
-			},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+			"integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			}
 		},
 		"node_modules/gopd": {
@@ -3127,7 +3176,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -3138,17 +3186,16 @@
 			"license": "MIT"
 		},
 		"node_modules/gtoken": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
-			"integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+			"version": "8.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0-rc.1.tgz",
+			"integrity": "sha512-UjE/egX6ixArdcCKOkheuFQ4XN4/0gX92nd2JPVEYuRU2sWHAWuOVGnowm1fQUdQtaxqn1n8H0hOb2LCaUhJ3A==",
 			"license": "MIT",
 			"dependencies": {
-				"gaxios": "^4.0.0",
-				"google-p12-pem": "^3.1.3",
+				"gaxios": "^7.0.0-rc.1",
 				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/has-bigints": {
@@ -3242,6 +3289,22 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -3256,17 +3319,29 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+		"node_modules/http-proxy-agent/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "6",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/human-signals": {
@@ -3651,6 +3726,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -3692,18 +3768,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-string": {
@@ -3877,7 +3941,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
@@ -3887,12 +3950,12 @@
 			}
 		},
 		"node_modules/jwa": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"license": "MIT",
 			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
+				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
 				"safe-buffer": "^5.0.1"
 			}
@@ -4063,12 +4126,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"license": "MIT"
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4125,18 +4182,6 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4175,6 +4220,27 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -4231,24 +4297,15 @@
 		},
 		"node_modules/node-fetch": {
 			"name": "@hackolade/fetch",
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@hackolade/fetch/-/fetch-1.2.1.tgz",
-			"integrity": "sha512-XCN7a7oLOajZryVCvhAOacRzTwMi6MoZmBe/A5GIPUyhirsAY3kUfWoMVE4kwAzmTBm/kALto1S3wO6SNGAvlw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@hackolade/fetch/-/fetch-1.3.0.tgz",
+			"integrity": "sha512-c148fu1kccwRxmLJ2UoW0EZyXU2gHSuCc6iT2LYYfa78ZNIsvAE/QVh3+CWyianhQL/vmivfUXvRHBFLPWXTJA==",
 			"license": "MIT",
 			"dependencies": {
 				"@smithy/fetch-http-handler": "4.0.0",
 				"@smithy/protocol-http": "4.1.5",
 				"@smithy/querystring-builder": "3.0.8",
 				"@smithy/types": "3.6.0"
-			}
-		},
-		"node_modules/node-forge": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-			"license": "(BSD-3-Clause OR GPL-2.0)",
-			"engines": {
-				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/normalize-path": {
@@ -4448,30 +4505,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/p-event": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-			"integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-			"license": "MIT",
-			"dependencies": {
-				"p-timeout": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4518,18 +4551,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-			"license": "MIT",
-			"dependencies": {
-				"p-finally": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/parent-module": {
@@ -4666,12 +4687,6 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
-		},
-		"node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -4840,16 +4855,17 @@
 			}
 		},
 		"node_modules/retry-request": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
-			"integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.0.tgz",
+			"integrity": "sha512-dJkZNmyV9C8WKUmbdj1xcvVlXBSvsUQCkg89TCK8rD72RdSn9A2jlXlS2VuYSTHoPJjJEfUHhjNYrlvuksF9cg==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.1.1",
-				"extend": "^3.0.2"
+				"@types/request": "^2.48.12",
+				"extend": "^3.0.2",
+				"teeny-request": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/reusify": {
@@ -4972,6 +4988,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -5443,19 +5460,43 @@
 			}
 		},
 		"node_modules/teeny-request": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.2.0.tgz",
-			"integrity": "sha512-SyY0pek1zWsi0LRVAALem+avzMLc33MKW/JLLakdP4s9+D7+jHcy5x6P+h94g2QNZsAqQNfX5lsbd3WSeJXrrw==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
+			"integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
-				"node-fetch": "^2.6.1",
-				"stream-events": "^1.0.5",
-				"uuid": "^8.0.0"
+				"node-fetch": "^3.3.2",
+				"stream-events": "^1.0.5"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			}
+		},
+		"node_modules/teeny-request/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/teeny-request/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/text-table": {
@@ -5648,11 +5689,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
@@ -5683,15 +5729,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
-		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -5872,12 +5909,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"license": "ISC"
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"license": "ISC"
 		},
 		"node_modules/yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 			"dependencies": {
 				"@google-cloud/bigquery": "8.0.0",
 				"@hackolade/sql-select-statement-parser": "0.0.20",
-				"fs-extra": "11.3.0"
+				"fs-extra": "11.3.0",
+				"lodash": "4.17.21"
 			},
 			"devDependencies": {
 				"@hackolade/hck-esbuild-plugins-pack": "0.0.1",
@@ -4125,6 +4126,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "dependencies": {
         "@google-cloud/bigquery": "8.0.0",
         "@hackolade/sql-select-statement-parser": "0.0.20",
-        "fs-extra": "11.3.0"
+        "fs-extra": "11.3.0",
+        "lodash": "4.17.21"
     },
     "lint-staged": {
         "*.{js,json}": "prettier --write"

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "description": "Hackolade plugin for Google BigQuery Standard SQL",
     "disabled": false,
     "dependencies": {
-        "@google-cloud/bigquery": "5.7.1",
+        "@google-cloud/bigquery": "8.0.0",
         "@hackolade/sql-select-statement-parser": "0.0.20",
-        "lodash": "4.17.21"
+        "fs-extra": "11.3.0"
     },
     "lint-staged": {
         "*.{js,json}": "prettier --write"
@@ -87,7 +87,7 @@
     },
     "overrides": {
         "node-fetch": {
-            ".": "npm:@hackolade/fetch@1.2.1"
+            ".": "npm:@hackolade/fetch@1.3.0"
         }
     }
 }

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -21,7 +21,7 @@ const getDatabases = async (connectionInfo, logger, callback, app) => {
 			hiddenKeys: connectionInfo.hiddenKeys,
 			logger,
 		});
-		const client = connect(connectionInfo, logger);
+		const client = await connect(connectionInfo, logger);
 		const bigQueryHelper = createBigQueryHelper(client, log);
 		const rawDatasets = connectionInfo.datasetId
 			? [{ id: connectionInfo.datasetId }]
@@ -33,7 +33,7 @@ const getDatabases = async (connectionInfo, logger, callback, app) => {
 	}
 };
 
-const connect = (connectionInfo, logger) => {
+const connect = async (connectionInfo, logger) => {
 	logger.clear();
 	logger.log('info', connectionInfo, 'connectionInfo', connectionInfo.hiddenKeys);
 
@@ -47,7 +47,7 @@ const testConnection = async (connectionInfo, logger, cb) => {
 			hiddenKeys: connectionInfo.hiddenKeys,
 			logger,
 		});
-		const client = connect(connectionInfo, logger);
+		const client = await connect(connectionInfo, logger);
 		const bigQueryHelper = createBigQueryHelper(client, log);
 		await bigQueryHelper.getDatasets();
 
@@ -72,17 +72,18 @@ const disconnect = async (connectionInfo, logger, cb) => {
 
 const getDbCollectionsNames = async (connectionInfo, logger, cb, app) => {
 	try {
-		const async = app.require('async');
 		const log = createLogger({
 			title: 'Reverse-engineering process',
 			hiddenKeys: connectionInfo.hiddenKeys,
 			logger,
 		});
-		const client = connect(connectionInfo, logger);
+		const client = await connect(connectionInfo, logger);
 		const bigQueryHelper = createBigQueryHelper(client, log);
 		const datasetName = connectionInfo.datasetId || connectionInfo.data?.databaseName;
 		const datasets = datasetName ? [{ id: datasetName }] : await bigQueryHelper.getDatasets();
-		const tablesByDataset = await async.mapSeries(datasets, async dataset => {
+		const tablesByDataset = await datasets.reduce(async (promise, dataset) => {
+			const result = await promise;
+
 			const tables = await bigQueryHelper.getTables(dataset.id);
 			const viewTypes = ['MATERIALIZED_VIEW', 'VIEW'];
 			const dbCollections = tables.filter(t => !viewTypes.includes(t.metadata.type)).map(table => table.id);
@@ -90,13 +91,16 @@ const getDbCollectionsNames = async (connectionInfo, logger, cb, app) => {
 				.filter(t => viewTypes.includes(t.metadata.type))
 				.map(table => bigQueryHelper.getViewName(table.id));
 
-			return {
-				isEmpty: tables.length === 0,
-				dbName: dataset.id,
-				dbCollections,
-				views,
-			};
-		});
+			return [
+				...result,
+				{
+					isEmpty: tables.length === 0,
+					dbName: dataset.id,
+					dbCollections,
+					views,
+				},
+			];
+		}, []);
 
 		cb(null, tablesByDataset);
 	} catch (err) {
@@ -109,9 +113,7 @@ const getDbCollectionsNames = async (connectionInfo, logger, cb, app) => {
 
 const getDbCollectionsData = async (data, logger, cb, app) => {
 	try {
-		const _ = app.require('lodash');
-		const async = app.require('async');
-		const client = connect(data, logger);
+		const client = await connect(data, logger);
 		const log = createLogger({
 			title: 'Reverse-engineering process',
 			hiddenKeys: data.hiddenKeys,
@@ -126,7 +128,9 @@ const getDbCollectionsData = async (data, logger, cb, app) => {
 			projectName: project.friendlyName,
 		};
 		let relationships = [];
-		const packages = await async.reduce(data.collectionData.dataBaseNames, [], async (result, datasetName) => {
+		const packages = await data.collectionData.dataBaseNames.reduce(async (promise, datasetName) => {
+			let result = await promise;
+
 			log.info(`Process dataset "${datasetName}"`);
 			log.progress(`Process dataset "${datasetName}"`, datasetName);
 
@@ -134,7 +138,6 @@ const getDbCollectionsData = async (data, logger, cb, app) => {
 			const bucketInfo = getBucketInfo({
 				metadata: dataset.metadata,
 				datasetName,
-				_,
 			});
 			const { tables, views } = data.collectionData.collections[datasetName]?.length
 				? getSpecificTablesAndViews(data, datasetName)
@@ -150,7 +153,9 @@ const getDbCollectionsData = async (data, logger, cb, app) => {
 			log.info(`Getting dataset constraints "${datasetName}"`);
 			log.progress(`Getting dataset constraints "${datasetName}"`, datasetName);
 
-			const collectionPackages = await async.mapSeries(tables, async tableName => {
+			const collectionPackages = await tables.reduce(async (promise, tableName) => {
+				const result = await promise;
+
 				log.info(`Get table metadata: "${tableName}"`);
 				log.progress(`Get table metadata`, datasetName, tableName);
 
@@ -176,21 +181,26 @@ const getDbCollectionsData = async (data, logger, cb, app) => {
 				};
 				const documents = convertValue(rows);
 
-				return {
-					dbName: bucketInfo.name,
-					collectionName: friendlyName || tableName,
-					entityLevel: { ...getTableInfo({ _, table, tableName }), primaryKey },
-					documents: documents,
-					standardDoc: documents[0],
-					views: [],
-					emptyBucket: false,
-					validation: {
-						jsonSchema,
+				return [
+					...result,
+					{
+						dbName: bucketInfo.name,
+						collectionName: friendlyName || tableName,
+						entityLevel: { ...getTableInfo({ table, tableName }), primaryKey },
+						documents: documents,
+						standardDoc: documents[0],
+						views: [],
+						emptyBucket: false,
+						validation: {
+							jsonSchema,
+						},
+						bucketInfo,
 					},
-					bucketInfo,
-				};
-			});
-			const viewsPackages = await async.mapSeries(views, async viewName => {
+				];
+			}, []);
+			const viewsPackages = await views.reduce(async (promise, viewName) => {
+				const result = await promise;
+
 				log.info(`Get view metadata: "${viewName}"`);
 				log.progress(`Get view metadata`, datasetName, viewName);
 
@@ -204,34 +214,38 @@ const getDbCollectionsData = async (data, logger, cb, app) => {
 
 				const viewJsonSchema = createJsonSchema(view.metadata.schema ?? {});
 
-				return {
-					dbName: bucketInfo.name,
-					name: friendlyName || viewName,
-					jsonSchema: createViewSchema({
-						viewQuery: viewData.query,
-						tablePackages: collectionPackages,
-						viewJsonSchema,
-						log,
-					}),
-					data: {
+				return [
+					...result,
+					{
+						dbName: bucketInfo.name,
 						name: friendlyName || viewName,
-						code: friendlyName ? viewName : '',
-						materialized: view.metadata.type === 'MATERIALIZED_VIEW',
-						description: view.metadata.description,
-						selectStatement: viewData.query,
-						labels: getLabels(_, view.metadata.labels),
-						expiration: view.metadata.expirationTime ? Number(view.metadata.expirationTime) : undefined,
-						clusteringKey: view.metadata.clustering?.fields || [],
-						...getPartitioning(view.metadata),
-						enableRefresh: Boolean(viewData?.enableRefresh),
-						refreshInterval: isNaN(viewData?.refreshIntervalMs)
-							? ''
-							: Number(viewData?.refreshIntervalMs) / (60 * 1000),
-						maxStaleness: view.metadata.maxStaleness,
-						allowNonIncrementalDefinition: view.metadata?.materializedView?.allowNonIncrementalDefinition,
+						jsonSchema: createViewSchema({
+							viewQuery: viewData.query,
+							tablePackages: collectionPackages,
+							viewJsonSchema,
+							log,
+						}),
+						data: {
+							name: friendlyName || viewName,
+							code: friendlyName ? viewName : '',
+							materialized: view.metadata.type === 'MATERIALIZED_VIEW',
+							description: view.metadata.description,
+							selectStatement: viewData.query,
+							labels: getLabels(view.metadata.labels),
+							expiration: view.metadata.expirationTime ? Number(view.metadata.expirationTime) : undefined,
+							clusteringKey: view.metadata.clustering?.fields || [],
+							...getPartitioning(view.metadata),
+							enableRefresh: Boolean(viewData?.enableRefresh),
+							refreshInterval: isNaN(viewData?.refreshIntervalMs)
+								? ''
+								: Number(viewData?.refreshIntervalMs) / (60 * 1000),
+							maxStaleness: view.metadata.maxStaleness,
+							allowNonIncrementalDefinition:
+								view.metadata?.materializedView?.allowNonIncrementalDefinition,
+						},
 					},
-				};
-			});
+				];
+			}, []);
 
 			result = result.concat(collectionPackages);
 
@@ -244,7 +258,7 @@ const getDbCollectionsData = async (data, logger, cb, app) => {
 			}
 
 			return result;
-		});
+		}, []);
 
 		cb(null, packages, modelInfo, relationships);
 	} catch (err) {
@@ -262,9 +276,9 @@ const getSpecificTablesAndViews = (data, datasetName) => {
 const getTablesAndViews = async dataset => {
 	const collectionsInContainer = (await dataset.getTables()).flat();
 
-	const tables = collectionsInContainer.filter(({ metadata }) => metadata.type === 'TABLE').map(({ id }) => id);
+	const tables = collectionsInContainer.filter(({ metadata }) => metadata?.type === 'TABLE').map(({ id }) => id);
 	const views = collectionsInContainer
-		.filter(({ metadata }) => metadata.type === 'VIEW' || metadata.type === 'MATERIALIZED_VIEW')
+		.filter(({ metadata }) => metadata?.type === 'VIEW' || metadata?.type === 'MATERIALIZED_VIEW')
 		.map(({ id }) => id);
 
 	return { tables, views };
@@ -297,7 +311,7 @@ const createLogger = ({ title, logger, hiddenKeys }) => {
 	};
 };
 
-const getBucketInfo = ({ _, metadata, datasetName }) => {
+const getBucketInfo = ({ metadata, datasetName }) => {
 	const name = metadata?.datasetReference?.datasetId;
 	const friendlyName = metadata.friendlyName;
 
@@ -307,7 +321,7 @@ const getBucketInfo = ({ _, metadata, datasetName }) => {
 		datasetID: metadata.id,
 		dataLocation: (metadata.location || '').toLowerCase(),
 		description: metadata.description || '',
-		labels: getLabels(_, metadata.labels),
+		labels: getLabels(metadata.labels),
 		enableTableExpiration: Boolean(metadata.defaultTableExpirationMs),
 		defaultExpiration: !isNaN(metadata.defaultTableExpirationMs)
 			? metadata.defaultTableExpirationMs / (1000 * 60 * 60 * 24)
@@ -316,8 +330,12 @@ const getBucketInfo = ({ _, metadata, datasetName }) => {
 	};
 };
 
-const getLabels = (_, labels) => {
-	return _.keys(labels).map(labelKey => ({ labelKey, labelValue: labels[labelKey] }));
+const getLabels = labels => {
+	if (!labels) {
+		return [];
+	}
+
+	return Object.keys(labels).map(labelKey => ({ labelKey, labelValue: labels[labelKey] }));
 };
 
 const getViewName = viewName => {
@@ -330,7 +348,7 @@ const getViewName = viewName => {
 	return '';
 };
 
-const getTableInfo = ({ _, table, tableName }) => {
+const getTableInfo = ({ table, tableName }) => {
 	const metadata = table.metadata || {};
 	const collectionName = metadata.friendlyName || tableName;
 
@@ -343,7 +361,7 @@ const getTableInfo = ({ _, table, tableName }) => {
 		expiration: metadata.expirationTime ? Number(metadata.expirationTime) : undefined,
 		clusteringKey: metadata.clustering?.fields || [],
 		...getEncryption(metadata.encryptionConfiguration),
-		labels: getLabels(_, metadata.labels),
+		labels: getLabels(metadata.labels),
 		tableOptions: getExternalOptions(metadata),
 	};
 };

--- a/reverse_engineering/helpers/bigQueryHelper.js
+++ b/reverse_engineering/helpers/bigQueryHelper.js
@@ -7,13 +7,15 @@ const createBigQueryHelper = (client, log) => {
 
 	const getPrimaryKeyConstraintsData = async (projectId, datasetId) => {
 		try {
-			return await client.query({
-				query: `SELECT * 
+			return (
+				await client.query({
+					query: `SELECT * 
 				FROM ${projectId}.${datasetId}.INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU
 				INNER JOIN ${projectId}.${datasetId}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC
 				USING(constraint_name)
 				WHERE TC.constraint_type = "PRIMARY KEY";`,
-			});
+				})
+			)[0];
 		} catch (error) {
 			log.warn('Error while getting table constraints', error);
 			return [];
@@ -22,8 +24,9 @@ const createBigQueryHelper = (client, log) => {
 
 	const getForeignKeyConstraintsData = async (projectId, datasetId) => {
 		try {
-			return await client.query({
-				query: `SELECT 
+			return (
+				await client.query({
+					query: `SELECT 
 				CCU.column_name as \`parent_column\`,
 				KCU.column_name as \`child_column\`,
 				TC.constraint_catalog, 
@@ -41,7 +44,8 @@ const createBigQueryHelper = (client, log) => {
 				INNER JOIN ${projectId}.${datasetId}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC
 				USING(constraint_name)
 				WHERE TC.constraint_type = "FOREIGN KEY";`,
-			});
+				})
+			)[0];
 		} catch (error) {
 			log.warn('Error while getting table constraints', error);
 			return [];
@@ -49,11 +53,11 @@ const createBigQueryHelper = (client, log) => {
 	};
 
 	const getConstraintsData = async (projectId, datasetId) => {
-		const primaryKeyConstraintsData = (await getPrimaryKeyConstraintsData(projectId, datasetId)).flat();
-		const foreignKeyConstraintsData = (await getForeignKeyConstraintsData(projectId, datasetId)).flat();
+		const primaryKeyConstraintsData = await getPrimaryKeyConstraintsData(projectId, datasetId);
+		const foreignKeyConstraintsData = await getForeignKeyConstraintsData(projectId, datasetId);
 		return {
-			primaryKeyConstraintsData,
-			foreignKeyConstraintsData,
+			primaryKeyConstraintsData: primaryKeyConstraintsData.flat(),
+			foreignKeyConstraintsData: foreignKeyConstraintsData.flat(),
 		};
 	};
 

--- a/reverse_engineering/helpers/connectionHelper.js
+++ b/reverse_engineering/helpers/connectionHelper.js
@@ -1,18 +1,19 @@
-const { BigQuery } = require('@google-cloud/bigquery');
+const { BigQuery, credentials } = require('@google-cloud/bigquery');
+const fsExtra = require('fs-extra');
 
 let client = null;
 
-const connect = connectionInfo => {
+const connect = async connectionInfo => {
 	if (client) {
 		return client;
 	}
 
 	const projectId = connectionInfo.projectId;
-	const keyFilename = connectionInfo.keyFilename;
 	const location = connectionInfo.location;
+	const credentials = await fsExtra.readJson(connectionInfo.keyFilename);
 
 	client = new BigQuery({
-		keyFilename,
+		credentials,
 		location,
 		projectId,
 		scopes: ['https://www.googleapis.com/auth/bigquery', 'https://www.googleapis.com/auth/drive'],


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10923" title="HCK-10923" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10923</a>  3) BigQuery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Add support for RE in the browser.

## Technical details

* Upgraded BigQuery lib. Now on `client.request` it returns content with metadata, so I had to change it a bit. And `dataset.getTables()` also returns metadata
* lib `async` doesn't work in the browser. I removed it.
* Lodash was used in one place, I removed it
* Now we need `fs-extra` because in the web worker it will read the file content from IndexedDB