### PR TITLE
HCK-10926: improve logging of error that happens on fetching primary and foreign keys

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -291,7 +291,15 @@ const createLogger = ({ title, logger, hiddenKeys }) => {
 		},
 
 		warn(message, context) {
-			logger.log('info', { message: '[warning] ' + message, context }, title, hiddenKeys);
+			logger.log(
+				'info',
+				{
+					message: '[warning] ' + message,
+					context: JSON.parse(JSON.stringify(context, Object.getOwnPropertyNames(context))),
+				},
+				title,
+				hiddenKeys,
+			);
 		},
 
 		progress(message, dbName = '', tableName = '') {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10926" title="HCK-10926" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10926</a>  Write auto tests for both Desktop&Browser
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# before
```
2025-06-18T10:37:45.120Z Reverse-engineering process:
{
  "message": "[warning] Error while getting table constraints",
  "context": {}
}
```

# after
```
2025-06-18T10:41:27.510Z Reverse-engineering process:
{
  "message": "[warning] Error while getting table constraints",
  "context": {
    "stack": "TypeError: (0 , crypto_1.randomUUID) is not a function
    at BigQuery.buildQueryRequest_ (http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:3996:48)
    at BigQuery.query (http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:3878:31)
    at http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:10633:28
    at new Promise (<anonymous>)
    at BigQuery.wrapper (http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:10618:16)
    at getPrimaryKeyConstraintsData (http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:690:28)
    at Object.getConstraintsData (http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:730:43)
    at http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:196:32
    at async http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:181:20
    at async Module.getDbCollectionsData (http://localhost:8080/plugins.BigQuery-api-re-js.re.cf3fa1f05eaecd36b4c4.js:180:20)",
    "message": "(0 , crypto_1.randomUUID) is not a function"
  }
}
```
