### PR TITLE
HCK-14408: disable FE level selector

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -27,6 +27,7 @@
 			"name": "JSON Schema",
 			"keyword": "json",
 			"disableApplyScriptToInstance": true,
+			"disableFeLevelSelector": true,
 			"fileExtensions": [
 				{
 					"label": "JSON",

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -31,6 +31,23 @@ module.exports = (baseProvider, options, app) => {
 
 	const { joinActivatedAndDeactivatedStatements } = require('./utils/statementJoiner');
 
+	const hydrateSchema = (containerData, data) => {
+		const modelData = data?.modelData;
+
+		return {
+			databaseName: containerData.name,
+			friendlyName: containerData.businessName,
+			description: containerData.description,
+			isActivated: containerData.isActivated,
+			ifNotExist: containerData.ifNotExist,
+			projectId: modelData?.[0]?.projectID,
+			defaultExpiration: containerData.enableTableExpiration ? containerData.defaultExpiration : '',
+			customerEncryptionKey:
+				containerData.encryption === 'Customer-managed' ? containerData.customerEncryptionKey : '',
+			labels: Array.isArray(containerData.labels) ? containerData.labels : [],
+		};
+	};
+
 	return {
 		createSchema({
 			databaseName,
@@ -305,22 +322,8 @@ module.exports = (baseProvider, options, app) => {
 			};
 		},
 
-		hydrateSchema(containerData, data) {
-			const modelData = data?.modelData;
-
-			return {
-				databaseName: containerData.name,
-				friendlyName: containerData.businessName,
-				description: containerData.description,
-				isActivated: containerData.isActivated,
-				ifNotExist: containerData.ifNotExist,
-				projectId: modelData?.[0]?.projectID,
-				defaultExpiration: containerData.enableTableExpiration ? containerData.defaultExpiration : '',
-				customerEncryptionKey:
-					containerData.encryption === 'Customer-managed' ? containerData.customerEncryptionKey : '',
-				labels: Array.isArray(containerData.labels) ? containerData.labels : [],
-			};
-		},
+		hydrateSchema,
+		hydrateDatabase: hydrateSchema,
 
 		hydrateTable({ tableData, entityData, jsonSchema }) {
 			const data = entityData[0];

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -323,6 +323,7 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		hydrateSchema,
+		// Keep it because it was used to hydrate `dbData` for the API
 		hydrateDatabase: hydrateSchema,
 
 		hydrateTable({ tableData, entityData, jsonSchema }) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14408" title="HCK-14408" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14408</a>  [BigQuery]: FE JSON - Disable FE level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

1. Disable FE Level selector for the JSON format.
2. Both `hydrateSchema` and `hydrateDatabase` hydrate data for a container in the BigQuery plugin. It's easier to keep them both than to refactor all hydration functions for now (i.e., keep using `dbData` instead of updating all cases to use `schemaData`). But notice please that we don't need `createDatabase`, otherwise it will duplicate `CREATE SCHEMA`.