### PR TITLE
HCK-14639: Generate an ALTER script for a renamed column

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -1,3 +1,4 @@
+const { getFullName } = require('../../helpers/utils');
 const { getModifyColumnNameScript } = require('./columnHelpers/nameHelper');
 const { getModifiedColumnOptionScripts } = require('./columnHelpers/optionsHelper');
 const { getModifyCollectionNameScript } = require('./entityHelpers/nameHelper');
@@ -69,8 +70,10 @@ module.exports = (app, options) => {
 		const idToActivatedHashTable = generateIdToActivatedHashTable(table);
 		const jsonSchema = setEntityKeys({ idToActivatedHashTable, idToNameHashTable, entity: table });
 		const tableName = getEntityName(jsonSchema);
+		const fullTableName = getFullName(dbData.projectId, dbData.databaseName, collection.role?.name || tableName);
+
 		const tableData = {
-			name: tableName,
+			name: fullTableName,
 			columns: [],
 			foreignKeyConstraints: [],
 			columnDefinitions: [],
@@ -79,10 +82,10 @@ module.exports = (app, options) => {
 
 		const modifyEntityNameScript = getModifyCollectionNameScript({ app, collection, dbData });
 		const modifyTableOptionsScript = getModifyTableOptions({ jsonSchema, tableData });
-		const modifyColumnNamesScript = getModifyColumnNameScript({ app, collection, dbData });
+		const modifyColumnNamesScript = getModifyColumnNameScript({ app, collection, tableData });
 		const modifyColumnScripts = getModifyColumnScripts({ tableData, dbData, collection });
 
-		return [modifyTableOptionsScript, ...modifyColumnScripts, modifyEntityNameScript, modifyColumnNamesScript]
+		return [modifyEntityNameScript, modifyTableOptionsScript, modifyColumnNamesScript, ...modifyColumnScripts]
 			.filter(Boolean)
 			.join('\n\n');
 	};

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -1,3 +1,4 @@
+const { getModifyColumnNameScript } = require('./columnHelper/alterColumnNameHelper');
 const { getModifyCollectionNameScript } = require('./entityHelpers/nameHelper');
 
 module.exports = (app, options) => {
@@ -77,9 +78,12 @@ module.exports = (app, options) => {
 
 		const modifyEntityNameScript = getModifyCollectionNameScript({ app, collection, dbData });
 		const modifyTableOptionsScript = getModifyTableOptions({ jsonSchema, tableData });
+		const modifyColumnNamesScript = getModifyColumnNameScript({ app, collection, dbData });
 		const modifyColumnScripts = getModifyColumnScripts({ tableData, dbData, collection });
 
-		return [modifyEntityNameScript, modifyTableOptionsScript, ...modifyColumnScripts].filter(Boolean).join('\n\n');
+		return [modifyEntityNameScript, modifyTableOptionsScript, ...modifyColumnScripts, modifyColumnNamesScript]
+			.filter(Boolean)
+			.join('\n\n');
 	};
 
 	const getModifyTableOptions = ({ jsonSchema, tableData }) => {

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelper/alterColumnNameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelper/alterColumnNameHelper.js
@@ -1,12 +1,12 @@
-const _ = require('lodash');
+const { toPairs } = require('lodash');
 const templates = require('../../../configs/templates');
 const { wrapByBackticks } = require('../../../helpers/utils');
 
 const getModifyColumnNameScript = ({ app, collection, dbData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
-	const { getFullCollectionName } = require('../../../helpers/general')(app);
+	const { getFullName } = require('../../../helpers/general')(app);
 
-	const columnsToRename = _.toPairs(collection.properties).filter(([_, jsonSchema]) => {
+	const columnsToRename = toPairs(collection.properties).filter(([_, jsonSchema]) => {
 		const compMod = jsonSchema.compMod || {};
 		const { newField = {}, oldField = {} } = compMod;
 
@@ -14,7 +14,11 @@ const getModifyColumnNameScript = ({ app, collection, dbData }) => {
 	});
 
 	if (columnsToRename.length) {
-		const fullTableName = getFullCollectionName({ dbData, collection });
+		const fullTableName = getFullName(
+			dbData.projectId,
+			dbData.databaseName,
+			collection.role?.name || collection.name,
+		);
 		const alterStatements = columnsToRename
 			.map(([_, jsonSchema]) => {
 				const compMod = jsonSchema.compMod || {};

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelper/alterColumnNameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelper/alterColumnNameHelper.js
@@ -1,0 +1,44 @@
+const _ = require('lodash');
+const templates = require('../../../configs/templates');
+const { wrapByBackticks } = require('../../../helpers/utils');
+
+const getModifyColumnNameScript = ({ app, collection, dbData }) => {
+	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
+	const { getFullCollectionName } = require('../../../helpers/general')(app);
+
+	const columnsToRename = _.toPairs(collection.properties).filter(([_, jsonSchema]) => {
+		const compMod = jsonSchema.compMod || {};
+		const { newField = {}, oldField = {} } = compMod;
+
+		return newField.name && oldField.name && newField.name !== oldField.name;
+	});
+
+	if (columnsToRename.length) {
+		const fullTableName = getFullCollectionName({ dbData, collection });
+		const alterStatements = columnsToRename
+			.map(([_, jsonSchema]) => {
+				const compMod = jsonSchema.compMod || {};
+				const { newField = {}, oldField = {} } = compMod;
+
+				const isCollectionActivated = collection.isActivated;
+				const isActivated = isCollectionActivated && jsonSchema.isActivated;
+
+				return assignTemplates(templates.renameColumn, {
+					oldColumnName: wrapByBackticks(oldField.name),
+					newColumnName: wrapByBackticks(newField.name),
+				});
+			})
+			.join(',');
+
+		return assignTemplates(templates.alterTableStatement, {
+			name: fullTableName,
+			alterStatements,
+		});
+	}
+
+	return '';
+};
+
+module.exports = {
+	getModifyColumnNameScript,
+};

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelper/alterColumnNameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelper/alterColumnNameHelper.js
@@ -24,9 +24,6 @@ const getModifyColumnNameScript = ({ app, collection, dbData }) => {
 				const compMod = jsonSchema.compMod || {};
 				const { newField = {}, oldField = {} } = compMod;
 
-				const isCollectionActivated = collection.isActivated;
-				const isActivated = isCollectionActivated && jsonSchema.isActivated;
-
 				return assignTemplates(templates.renameColumn, {
 					oldColumnName: wrapByBackticks(oldField.name),
 					newColumnName: wrapByBackticks(newField.name),

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
@@ -1,10 +1,9 @@
 const { toPairs } = require('lodash');
 const templates = require('../../../configs/templates');
-const { wrapByBackticks } = require('../../../helpers/utils');
+const { wrapByBackticks, getFullName } = require('../../../helpers/utils');
 
 const getModifyColumnNameScript = ({ app, collection, dbData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
-	const { getFullName } = require('../../../helpers/general')(app);
 
 	const columnsToRename = toPairs(collection.properties).filter(([_, jsonSchema]) => {
 		const compMod = jsonSchema.compMod || {};

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
@@ -3,7 +3,8 @@ const templates = require('../../../configs/templates');
 const { wrapByBackticks, getFullName } = require('../../../helpers/utils');
 
 const getModifyColumnNameScript = ({ app, collection, tableData }) => {
-	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
+	const { tab } = app.require('@hackolade/ddl-fe-utils').general;
+	const assignTemplates = app.require('@hackolade/ddl-fe-utils').assignTemplates;
 
 	const columnsToRename = toPairs(collection.properties).filter(([_, jsonSchema]) => {
 		const compMod = jsonSchema.compMod || {};
@@ -23,11 +24,11 @@ const getModifyColumnNameScript = ({ app, collection, tableData }) => {
 					newColumnName: wrapByBackticks(newField.name),
 				});
 			})
-			.join(',');
+			.join(',\n');
 
 		return assignTemplates(templates.alterTableStatement, {
 			name: tableData.name,
-			alterStatements,
+			alterStatements: tab(alterStatements),
 		});
 	}
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
@@ -2,7 +2,7 @@ const { toPairs } = require('lodash');
 const templates = require('../../../configs/templates');
 const { wrapByBackticks, getFullName } = require('../../../helpers/utils');
 
-const getModifyColumnNameScript = ({ app, collection, dbData }) => {
+const getModifyColumnNameScript = ({ app, collection, tableData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
 
 	const columnsToRename = toPairs(collection.properties).filter(([_, jsonSchema]) => {
@@ -13,11 +13,6 @@ const getModifyColumnNameScript = ({ app, collection, dbData }) => {
 	});
 
 	if (columnsToRename.length) {
-		const fullTableName = getFullName(
-			dbData.projectId,
-			dbData.databaseName,
-			collection.role?.name || collection.name,
-		);
 		const alterStatements = columnsToRename
 			.map(([_, jsonSchema]) => {
 				const compMod = jsonSchema.compMod || {};
@@ -31,7 +26,7 @@ const getModifyColumnNameScript = ({ app, collection, dbData }) => {
 			.join(',');
 
 		return assignTemplates(templates.alterTableStatement, {
-			name: fullTableName,
+			name: tableData.name,
 			alterStatements,
 		});
 	}

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/optionsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/optionsHelper.js
@@ -10,8 +10,6 @@ const getModifiedColumnOptionScripts = ({ collection, app, tableData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
 	const { tab } = app.require('@hackolade/ddl-fe-utils').general;
 
-	const fullTableName = getFullName(tableData.dbData.projectId, tableData.dbData.databaseName, tableData.name);
-
 	return _.toPairs(collection.properties)
 		.map(([name, jsonSchema]) => {
 			const oldName = jsonSchema.compMod.oldField.name;
@@ -32,7 +30,7 @@ const getModifiedColumnOptionScripts = ({ collection, app, tableData }) => {
 			}
 
 			return assignTemplates(templates.alterColumnOptions, {
-				tableName: fullTableName,
+				tableName: tableData.name,
 				columnName: wrapByBackticks(oldName),
 				options: tab(optionsToUpdate.join(',\n')),
 			});

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -1,5 +1,5 @@
-const templates = require('../../../configs/templates');
 const { wrapByBackticks, getFullName } = require('../../../helpers/utils');
+const templates = require('../../../configs/templates');
 
 const getModifyCollectionNameScript = ({ app, collection, dbData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -1,4 +1,5 @@
 const templates = require('../../..//configs/templates');
+const { wrapByBackticks } = require('../../../helpers/utils');
 
 const getModifyCollectionNameScript = ({ app, collection, dbData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
@@ -17,8 +18,8 @@ const getModifyCollectionNameScript = ({ app, collection, dbData }) => {
 	const fullTableName = [dbData.projectId, dbData.databaseName, name].filter(Boolean).join('.');
 
 	return assignTemplates(templates.renameTable, {
-		oldTableName: `\`${fullTableName}\``,
-		newTableName: `\`${newName}\``,
+		oldTableName: wrapByBackticks(fullTableName),
+		newTableName: wrapByBackticks(newName),
 	});
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -3,6 +3,7 @@ const { wrapByBackticks } = require('../../../helpers/utils');
 
 const getModifyCollectionNameScript = ({ app, collection, dbData }) => {
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
+	const { getFullName } = require('../../../helpers/general')(app);
 	const collectionName = collection?.role?.compMod?.collectionName;
 
 	if (!collectionName) {
@@ -15,10 +16,10 @@ const getModifyCollectionNameScript = ({ app, collection, dbData }) => {
 		return undefined;
 	}
 
-	const fullTableName = [dbData.projectId, dbData.databaseName, name].filter(Boolean).join('.');
+	const fullTableName = getFullName(dbData.projectId, dbData.databaseName, name);
 
 	return assignTemplates(templates.renameTable, {
-		oldTableName: wrapByBackticks(fullTableName),
+		oldTableName: fullTableName,
 		newTableName: wrapByBackticks(newName),
 	});
 };

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -31,13 +31,13 @@ module.exports = {
 
 	alterTableDropColumn: 'ALTER TABLE ${tableName} DROP COLUMN IF EXISTS ${columnName};',
 
-	renameColumn: '\n  RENAME COLUMN IF EXISTS ${oldColumnName} TO ${newColumnName}',
+	renameColumn: 'RENAME COLUMN IF EXISTS ${oldColumnName} TO ${newColumnName}',
 
 	dropView: 'DROP VIEW IF EXISTS ${name};',
 
 	alterViewOptions: 'ALTER ${materialized}VIEW ${name} SET ${options};',
 
-	alterTableStatement: 'ALTER TABLE IF EXISTS ${name} ${alterStatements};',
+	alterTableStatement: 'ALTER TABLE IF EXISTS ${name}\n${alterStatements};',
 
 	renameTable: 'ALTER TABLE IF EXISTS ${oldTableName} RENAME TO ${newTableName};',
 };

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -31,7 +31,7 @@ module.exports = {
 
 	alterTableDropColumn: 'ALTER TABLE ${tableName} DROP COLUMN IF EXISTS ${columnName};',
 
-	renameColumn: '\n RENAME COLUMN IF EXISTS ${oldColumnName} TO ${newColumnName}',
+	renameColumn: '\n  RENAME COLUMN IF EXISTS ${oldColumnName} TO ${newColumnName}',
 
 	dropView: 'DROP VIEW IF EXISTS ${name};',
 

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -31,9 +31,13 @@ module.exports = {
 
 	alterTableDropColumn: 'ALTER TABLE ${tableName} DROP COLUMN IF EXISTS ${columnName};',
 
+	renameColumn: '\n RENAME COLUMN IF EXISTS ${oldColumnName} TO ${newColumnName}',
+
 	dropView: 'DROP VIEW IF EXISTS ${name};',
 
 	alterViewOptions: 'ALTER ${materialized}VIEW ${name} SET ${options};',
+
+	alterTableStatement: 'ALTER TABLE IF EXISTS ${name} ${alterStatements};',
 
 	renameTable: 'ALTER TABLE IF EXISTS ${oldTableName} RENAME TO ${newTableName};',
 };

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -550,7 +550,7 @@ module.exports = (baseProvider, options, app) => {
 			return assignTemplates(templates.alterColumnType, {
 				columnName: wrapByBackticks(columnDefinition.name),
 				type: columnSchema,
-				tableName: wrapByBackticks(columnDefinition.name),
+				tableName,
 			});
 		},
 

--- a/forward_engineering/helpers/general.js
+++ b/forward_engineering/helpers/general.js
@@ -4,6 +4,14 @@ module.exports = app => {
 	const _ = app.require('lodash');
 	const { commentIfDeactivated, tab } = app.require('@hackolade/ddl-fe-utils').general;
 
+	const getFullCollectionName = ({ dbData, collection }) => {
+		const projectId = dbData.projectId;
+		const databaseName = dbData.databaseName;
+		const tableName = collection.role?.name || collection.name;
+
+		return getFullName(projectId, databaseName, tableName);
+	};
+
 	const getFullName = (projectId, datasetName, tableName) => {
 		let name = [];
 
@@ -141,6 +149,7 @@ module.exports = app => {
 	return {
 		getLabels,
 		getFullName,
+		getFullCollectionName,
 		getContainerOptions,
 		getViewOptions,
 		cleanObject,

--- a/forward_engineering/helpers/general.js
+++ b/forward_engineering/helpers/general.js
@@ -1,33 +1,13 @@
+const _ = require('lodash');
 const { escapeQuotes, getTimestamp, wrapByBackticks } = require('./utils');
 
 module.exports = app => {
-	const _ = app.require('lodash');
 	const { commentIfDeactivated, tab } = app.require('@hackolade/ddl-fe-utils').general;
 
-	const getFullCollectionName = ({ dbData, collection }) => {
-		const projectId = dbData.projectId;
-		const databaseName = dbData.databaseName;
-		const tableName = collection.role?.name || collection.name;
-
-		return getFullName(projectId, databaseName, tableName);
-	};
-
 	const getFullName = (projectId, datasetName, tableName) => {
-		let name = [];
+		const name = [projectId, datasetName, tableName].filter(Boolean).join('.');
 
-		if (projectId) {
-			name.push(projectId);
-		}
-
-		if (datasetName) {
-			name.push(datasetName);
-		}
-
-		if (tableName) {
-			name.push(tableName);
-		}
-
-		return '`' + name.join('.') + '`';
+		return wrapByBackticks(name);
 	};
 
 	const getLabels = labels => {
@@ -149,7 +129,6 @@ module.exports = app => {
 	return {
 		getLabels,
 		getFullName,
-		getFullCollectionName,
 		getContainerOptions,
 		getViewOptions,
 		cleanObject,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14639" title="HCK-14639" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14639</a>  [BigQuery]: Generate an ALTER script for a renamed column
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Changed the order of statements
Added logic to rename columns within singe statement as described [here](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_rename_column_statement). 

<img width="1004" height="203" alt="Screenshot 2026-02-03 at 15 39 31" src="https://github.com/user-attachments/assets/699a9db2-5fde-4c9e-a530-56b2e6e64ad2" />
