### PR TITLE
HCK-14652: SQL is not generated for the DEFAULT property

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -1,4 +1,5 @@
 const { getFullName } = require('../../helpers/utils');
+const { getModifiedDefaultColumnValueScripts } = require('./columnHelpers/defaultConstraintHelper');
 const { getModifyColumnNameScript } = require('./columnHelpers/nameHelper');
 const { getModifiedColumnOptionScripts } = require('./columnHelpers/optionsHelper');
 const { getModifyCollectionNameScript } = require('./entityHelpers/nameHelper');
@@ -84,8 +85,15 @@ module.exports = (app, options) => {
 		const modifyTableOptionsScript = getModifyTableOptions({ jsonSchema, tableData });
 		const modifyColumnNamesScript = getModifyColumnNameScript({ app, collection, tableData });
 		const modifyColumnScripts = getModifyColumnScripts({ tableData, dbData, collection });
+		const modifyDefaultValueScripts = getModifiedDefaultColumnValueScripts({ app, collection, tableData });
 
-		return [modifyEntityNameScript, modifyTableOptionsScript, modifyColumnNamesScript, ...modifyColumnScripts]
+		return [
+			modifyEntityNameScript,
+			modifyTableOptionsScript,
+			modifyColumnNamesScript,
+			...modifyColumnScripts,
+			...modifyDefaultValueScripts,
+		]
 			.filter(Boolean)
 			.join('\n\n');
 	};

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultConstraintHelper.js
@@ -1,0 +1,59 @@
+const { toPairs } = require('lodash');
+const templates = require('../../../configs/templates');
+const { wrapByBackticks } = require('../../../helpers/utils');
+
+const getUpdatedDefaultColumnValueScript = ({ collection, commonProps }) => {
+	const { assignTemplates, tableName } = commonProps;
+
+	return toPairs(collection.properties)
+		.filter(([_name, jsonSchema]) => {
+			const newDefault = jsonSchema.default;
+			const oldName = jsonSchema.compMod.oldField.name;
+			const oldDefault = collection.role.properties[oldName]?.default;
+			return newDefault !== undefined && (!oldDefault || newDefault !== oldDefault);
+		})
+		.map(([columnName, jsonSchema]) => {
+			return assignTemplates(templates.alterTableSetDefault, {
+				tableName,
+				columnName: wrapByBackticks(columnName),
+				default: jsonSchema.default,
+			});
+		});
+};
+
+const getDeletedDefaultColumnValueScript = ({ collection, commonProps }) => {
+	const { assignTemplates, tableName } = commonProps;
+
+	return toPairs(collection.properties)
+		.filter(([_name, jsonSchema]) => {
+			const newDefault = jsonSchema.default;
+			const oldName = jsonSchema.compMod.oldField.name;
+			const oldDefault = collection.role.properties[oldName]?.default;
+			const hasPrevValue = oldDefault !== undefined;
+			const hasNewValue = newDefault !== undefined;
+			return hasPrevValue && !hasNewValue;
+		})
+		.map(([columnName, jsonSchema]) => {
+			return assignTemplates(templates.alterTableDropDefault, {
+				tableName,
+				columnName: wrapByBackticks(columnName),
+			});
+		});
+};
+
+const getModifiedDefaultColumnValueScripts = ({ app, collection, tableData }) => {
+	const assignTemplates = app.require('@hackolade/ddl-fe-utils').assignTemplates;
+
+	const commonProps = {
+		assignTemplates,
+		tableName: tableData.name,
+	};
+
+	const updatedDefaultValuesScriptDtos = getUpdatedDefaultColumnValueScript({ collection, commonProps });
+	const dropDefaultValuesScriptDtos = getDeletedDefaultColumnValueScript({ collection, commonProps });
+	return [...updatedDefaultValuesScriptDtos, ...dropDefaultValuesScriptDtos];
+};
+
+module.exports = {
+	getModifiedDefaultColumnValueScripts,
+};

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nameHelper.js
@@ -1,6 +1,6 @@
 const { toPairs } = require('lodash');
 const templates = require('../../../configs/templates');
-const { wrapByBackticks, getFullName } = require('../../../helpers/utils');
+const { wrapByBackticks } = require('../../../helpers/utils');
 
 const getModifyColumnNameScript = ({ app, collection, tableData }) => {
 	const { tab } = app.require('@hackolade/ddl-fe-utils').general;

--- a/forward_engineering/alterScript/alterScriptHelpers/createColumnDefinition.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/createColumnDefinition.js
@@ -80,7 +80,7 @@ module.exports = _ => {
 
 	const createColumnDefinitionBySchema = ({ name, jsonSchema, parentJsonSchema, ddlProvider, schemaData }) => {
 		const columnDefinition = createColumnDefinition({
-			name: name,
+			name,
 			type: getType(jsonSchema),
 			nullable: isNullable(parentJsonSchema, name),
 			default: getDefault(jsonSchema),

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -31,6 +31,11 @@ module.exports = {
 
 	alterTableDropColumn: 'ALTER TABLE ${tableName} DROP COLUMN IF EXISTS ${columnName};',
 
+	alterTableSetDefault:
+		'ALTER TABLE IF EXISTS ${tableName} ALTER COLUMN IF EXISTS ${columnName}\nSET DEFAULT ${default};',
+
+	alterTableDropDefault: 'ALTER TABLE IF EXISTS ${tableName} ALTER COLUMN IF EXISTS ${columnName}\nDROP DEFAULT;',
+
 	renameColumn: 'RENAME COLUMN IF EXISTS ${oldColumnName} TO ${newColumnName}',
 
 	dropView: 'DROP VIEW IF EXISTS ${name};',

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -4,7 +4,7 @@ module.exports = {
 	createTable:
 		'CREATE ${orReplace}${temporary}${external}TABLE ${ifNotExist}${name} ${column_definitions}${partitions}${clustering}${options};\n',
 
-	columnDefinition: '${name}${type}${primaryKey}${notNull}${options}',
+	columnDefinition: '${name}${type}${primaryKey}${default}${notNull}${options}',
 
 	createForeignKeyConstraint:
 		'${constraintName}FOREIGN KEY (${foreignKeys}) REFERENCES ${primaryTableName}(${primaryKeys}) NOT ENFORCED',

--- a/forward_engineering/helpers/utils.js
+++ b/forward_engineering/helpers/utils.js
@@ -305,6 +305,7 @@ const getColumnSchema =
 			primaryKey,
 			notNull,
 			options,
+			default: jsonSchema.default ? ` DEFAULT ${jsonSchema.default}` : '',
 		});
 	};
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14652" title="HCK-14652" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14652</a>  [BigQuery]: SQL is not generated for the DEFAULT property
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added logic to generate default values when tables are:

- newly created
- altered
