### PR TITLE
HCK-14680: It's impossible to unset PK

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -161,11 +161,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -459,11 +456,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -665,11 +659,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -871,11 +862,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -1092,11 +1080,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -1271,11 +1256,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -1558,11 +1540,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},
@@ -1740,11 +1719,8 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						{
-							"type": "not",
-							"values": {
-								"key": "unique",
-								"value": true
-							}
+							"key": "unique",
+							"value": true
 						}
 					]
 				},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14680" title="HCK-14680" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14680</a>  It's impossible to unset PK
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

These unique block clauses are part of **disabledOnCondition**, not **dependency**, so I removed `"type": "not"`. I could rework the types to match the **dependency** pattern, but that feels riskier than this simple fix.