### PR TITLE
fix: set empty string when column description removed

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/optionsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/optionsHelper.js
@@ -20,8 +20,8 @@ const getModifiedColumnOptionScripts = ({ collection, app, tableData }) => {
 				const oldOptionValue = collection.role.properties[oldName]?.[customOptionName];
 
 				if (newOptionValue !== oldOptionValue) {
-					const value = newOptionValue ? escapeQuotes(newOptionValue) : '';
-					optionsToUpdate.push(`${columnOptionName}="${value}"`);
+					const value = newOptionValue ? `"${escapeQuotes(newOptionValue)}"` : 'NULL';
+					optionsToUpdate.push(`${columnOptionName}=${value}`);
 				}
 			});
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/optionsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/optionsHelper.js
@@ -20,7 +20,7 @@ const getModifiedColumnOptionScripts = ({ collection, app, tableData }) => {
 				const oldOptionValue = collection.role.properties[oldName]?.[customOptionName];
 
 				if (newOptionValue !== oldOptionValue) {
-					const value = newOptionValue ? escapeQuotes(newOptionValue) : newOptionValue;
+					const value = newOptionValue ? escapeQuotes(newOptionValue) : '';
 					optionsToUpdate.push(`${columnOptionName}="${value}"`);
 				}
 			});


### PR DESCRIPTION
## Technical details

Currenty, it sets `"undefined"`. But set NULL when description is removed.