### PR TITLE
HCK-14751: Relationship isn't renamed but duplicated one is created on instance after Alter script with renamed relationship is applied

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -98,8 +98,19 @@ const getAlterViewScripts = (collection, app, modelData) => {
 };
 
 const getInlineRelationships = ({ data, options }) => {
-	// Will be implemented with script generation options
-	return [];
+	if (options?.scriptGenerationOptions?.feActiveOptions?.foreignKeys !== 'inline') {
+		return [];
+	}
+
+	const addedCollectionIDs = getItems(data.properties?.entities?.properties?.added)
+		.filter(item => item && Object.values(item.properties)?.[0]?.compMod?.created)
+		.map(item => Object.values(item.properties)[0].role.id);
+
+	const addedRelationships = getItems(data.properties?.relationships?.properties?.added)
+		.map(item => item && Object.values(item.properties)[0])
+		.filter(r => r?.role?.compMod?.created && addedCollectionIDs.includes(r?.role?.childCollection));
+
+	return addedRelationships;
 };
 
 const getAlterRelationshipsScript = ({ collection, app, modelData, ignoreRelationshipIDs = [] }) => {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterForeignKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterForeignKeyHelper.js
@@ -6,6 +6,11 @@ const getRelationshipName = ({ relationship }) => {
 	return compMod.code?.new || compMod.name?.new || relationship.role.code || relationship.role.name;
 };
 
+const getOldRelationshipName = ({ relationship }) => {
+	const compMod = relationship.role.compMod;
+	return compMod.code?.old || compMod.name?.old || relationship.role.code || relationship.role.name;
+};
+
 const getFullChildTableName = ({ relationship, modelData }) => {
 	const compMod = relationship.role.compMod;
 
@@ -94,7 +99,7 @@ const getAddForeignKeyScripts =
 const getDeleteSingleForeignKeyStatementDto = ({ app, relationship, modelData }) => {
 	const compMod = relationship.role.compMod;
 	const tableName = getFullChildTableName({ relationship, modelData });
-	const relationshipName = getRelationshipName({ relationship });
+	const relationshipName = getOldRelationshipName({ relationship });
 	const constraintName = prepareConstraintName(relationshipName);
 	const assignTemplates = app.require('@hackolade/ddl-fe-utils').assignTemplates;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14751" title="HCK-14751" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14751</a>  [BigQuery] relationship isn't renamed but duplicated one is created on instance after Alter script with renamed relationship is applied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Use old FK name in delete statement