### PR TITLE
HCK-14884: disable script options for json format

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -28,6 +28,7 @@
 			"keyword": "json",
 			"disableApplyScriptToInstance": true,
 			"disableFeLevelSelector": true,
+			"disableScriptGenerationOptions": true,
 			"fileExtensions": [
 				{
 					"label": "JSON",


### PR DESCRIPTION
## Technical details

Script generation options should be disabled for any format except ddl/sql. Otherwise, it might inject ALTER scripts to JSON file.

https://hackolade.atlassian.net/browse/HCK-14884