### PR TITLE
HCK-15891: fix FE of database/schema default properties to dbt

### DIFF
--- a/forward_engineering/dbtProvider.js
+++ b/forward_engineering/dbtProvider.js
@@ -76,6 +76,17 @@ class DbtProvider {
 			...(policyTags?.length && { policy_tags: policyTags }),
 		};
 	}
+
+	/**
+	 * @param {{ modelData: object[]; containerData: object[]; entityData: object[];}}
+	 * @returns {{ databaseName?: string, schemaName?: string }}
+	 */
+	getEntityProperties({ modelData, containerData, entityData }) {
+		return {
+			databaseName: modelData?.[0]?.projectID,
+			schemaName: containerData?.[0]?.code ?? containerData?.[0]?.name,
+		};
+	}
 }
 
 module.exports = DbtProvider;


### PR DESCRIPTION
## Content

In dbt the project ID is mapped to the `database` and the dataset is mapped to the `schema`