### PR TITLE
HCK-15836: hide Policy tags for dbt source group

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1985,7 +1985,17 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Policy tags",
 				"propertyKeyword": "dbtPolicyTags",
 				"propertyType": "multipleText",
-				"enableForReference": true
+				"enableForReference": true,
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"level": "container",
+							"key": "dbtSourceGroup",
+							"value": true
+						}
+					]
+				}
 			}
 		]
 	}


### PR DESCRIPTION
## Content

"Policy tags" property should be hidden if a parent container is a source group.