### PR TITLE
chore: address Trivy production dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "BigQuery",
-    "version": "0.2.29",
+    "version": "0.2.30",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "BigQuery",
-            "version": "0.2.29",
+            "version": "0.2.30",
             "hasInstallScript": true,
             "dependencies": {
                 "@google-cloud/bigquery": "8.1.1",
@@ -1605,9 +1605,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     },
     "overrides": {
         "@tootallnate/once": "3.0.1",
-        "brace-expansion": "5.0.8",
+        "brace-expansion": "5.0.9",
         "node-fetch": {
             ".": "npm:@hackolade/fetch@1.3.0"
         },


### PR DESCRIPTION
## Summary
- Address Trivy dependency vulnerabilities for `BigQuery`: brace-expansion override 5.0.8 → 5.0.9 (CVE-2026-69152).
- This plugin was listed in the Plugins released Trivy production report (build 287245).
- Reference: https://teamcity.hackolade.com/buildConfiguration/Plugins_Build/287245?buildTab=report_project9_Released_vulnerabilities

## Test plan
- [x] CI passes
- [x] Plugins released Trivy re-scan no longer reports the fixed package for this plugin
